### PR TITLE
Okta auth additional scope config

### DIFF
--- a/plugins/auth-backend-module-okta-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-okta-provider/src/authenticator.ts
@@ -32,6 +32,19 @@ export const oktaAuthenticator = createOAuthAuthenticator({
     const audience = config.getOptionalString('audience') || 'https://okta.com';
     const authServerId = config.getOptionalString('authServerId');
     const idp = config.getOptionalString('idp');
+    // default scopes are taken from
+    // https://developer.okta.com/docs/reference/api/oidc/#response-example-success-refresh-token
+    const defaultScopes = 'openid profile email';
+    // additional scopes can be configured in the config as a space separated string
+    const additionalScopes = config.getOptionalString('additionalScopes') || '';
+    // combine default and additional scopes and remove duplicates
+    const combineScopeStrings = (scopesA: string, scopesB: string) => {
+      const scopesAArray = scopesA.split(' ');
+      const scopesBArray = scopesB.split(' ');
+      const combinedScopes = new Set([...scopesAArray, ...scopesBArray]);
+      return Array.from(combinedScopes).join(' ');
+    };
+    const scope = combineScopeStrings(defaultScopes, additionalScopes);
 
     return PassportOAuthAuthenticatorHelper.from(
       new OktaStrategy(
@@ -44,6 +57,7 @@ export const oktaAuthenticator = createOAuthAuthenticator({
           idp: idp,
           passReqToCallback: false,
           response_type: 'code',
+          scope,
         },
         (
           accessToken: string,

--- a/plugins/auth-backend-module-okta-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-okta-provider/src/module.test.ts
@@ -21,6 +21,9 @@ import { decodeOAuthState } from '@backstage/plugin-auth-node';
 
 describe('authModuleOktaProvider', () => {
   it('should start', async () => {
+    const defaultScopes = 'openid profile email';
+    const additionalScopes = 'groups phone';
+    const combinedScopes = `${defaultScopes} ${additionalScopes}`;
     const { server } = await startTestBackend({
       features: [
         import('@backstage/plugin-auth-backend'),
@@ -36,6 +39,7 @@ describe('authModuleOktaProvider', () => {
                   development: {
                     clientId: 'my-client-id',
                     clientSecret: 'my-client-secret',
+                    additionalScopes,
                   },
                 },
               },
@@ -64,7 +68,7 @@ describe('authModuleOktaProvider', () => {
     expect(startUrl.pathname).toBe('/oauth2/v1/authorize');
     expect(Object.fromEntries(startUrl.searchParams)).toEqual({
       response_type: 'code',
-      scope: 'read_user',
+      scope: combinedScopes,
       client_id: 'my-client-id',
       redirect_uri: `http://localhost:${server.port()}/api/auth/okta/handler/frame`,
       state: expect.any(String),

--- a/plugins/auth-backend-module-okta-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-okta-provider/src/module.test.ts
@@ -61,7 +61,7 @@ describe('authModuleOktaProvider', () => {
 
     const startUrl = new URL(res.get('location'));
     expect(startUrl.origin).toBe('https://okta.com');
-    expect(startUrl.pathname).toBe('/oauth/authorize');
+    expect(startUrl.pathname).toBe('/oauth2/v1/authorize');
     expect(Object.fromEntries(startUrl.searchParams)).toEqual({
       response_type: 'code',
       scope: 'read_user',


### PR DESCRIPTION
- Sets a default scope value of `openid profile email` based on [the response example from Okta](https://developer.okta.com/docs/reference/api/oidc/#response-example-success-refresh-token) and my own testing of what the `scope` value is if none is explicitly provided
- Reads the config option for `additionalScopes`
- Combines the default scope and additional scopes
- Passes the combined scopes as [the `scope` option to Passport](https://www.passportjs.org/concepts/authentication/oauth/)
- Updates the unit test to cover `additionalScopes`
- Update the expected path in the unit test to use `/oauth2/v1/authorize` as defined in [the Okta OIDC API documentation](https://developer.okta.com/docs/reference/api/oidc/#composing-your-base-url)